### PR TITLE
MERC-9287 Remove resque dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'resque', '~>1.19'
-
 group :test do
   gem 'mocha', '~>0.9'
   gem 'minitest', '~> 5.5'

--- a/resque-status.gemspec
+++ b/resque-status.gemspec
@@ -51,14 +51,11 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<resque>, ["~> 1.19"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
-      s.add_dependency(%q<resque>, ["~> 1.19"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
-    s.add_dependency(%q<resque>, ["~> 1.19"])
     s.add_dependency(%q<jeweler>, [">= 0"])
   end
 end


### PR DESCRIPTION
The original library is not maintained anymore, but it still works fine with Resque 2.x. 
